### PR TITLE
Fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, David Hay and Contributers. All rights reserved.
+Copyright (c) 2016, David Hay and Contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
Fixing the typo at the top of the file. Not sure why the 2nd line is highlighted, I didn't change it.